### PR TITLE
Add DMCA policy and link in gallery (chnm#128)

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -2,6 +2,7 @@ from django.conf import settings
 from django.conf.urls.static import static
 from django.contrib import admin
 from django.contrib.auth import views as auth_views
+from django.views.generic.base import TemplateView
 from django.urls import include, path
 from wagtail import urls as wagtail_urls
 from wagtail.admin import urls as wagtailadmin_urls
@@ -19,6 +20,7 @@ urlpatterns = [
     path("prose/", include("prose.urls")),
     path("gallery/", include("gallery.urls", namespace="gallery")),
     path("cms/", include(wagtailadmin_urls)),
+    path("dmca/", TemplateView.as_view(template_name="dmca.html"), name="dmca"),
 ]
 
 if settings.DEBUG:

--- a/gallery/templates/gallery/gallery_index_page.html
+++ b/gallery/templates/gallery/gallery_index_page.html
@@ -6,9 +6,9 @@
     <h1 class="text-3xl font-bold mb-6">{{ page.title }}</h1>
     
     {% if page.intro %}
-    <div class="mb-8">{{ page.intro|richtext }}</div>
+        <div class="mb-8">{{ page.intro|richtext }}</div>
     {% endif %}
-    
+
     <!-- Theme filter with Alpine.js and HTMX -->
     <div class="mb-8" x-data="{ selectedTheme: '{{ current_theme|default:"" }}' }">
         <h2 class="text-xl font-semibold mb-3">Filter by Theme</h2>
@@ -63,5 +63,10 @@
     <div id="gallery-grid" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
         {% include "gallery/partials/gallery_grid.html" with gallery_pages=gallery_pages %}
     </div>
+
+    <p class="prose my-8">
+        Need to submit a takedown request for content posted here?
+        See our <a class="underline hover:no-underline" href="{% url 'dmca' %}">DMCA policy.</a>
+    </p>
 </div>
 {% endblock %}

--- a/templates/dmca.html
+++ b/templates/dmca.html
@@ -1,0 +1,67 @@
+{% extends "base.html" %}
+
+{% block title %}DMCA Policy - La Sfera{% endblock title %}
+
+{% block content %}
+  <div class="mx-auto container pt-3">
+    <section class="w-full p-4 my-10">
+      <h1 class="text-3xl font-bold mb-4">DMCA Policy</h1>
+
+      <p class="prose mb-4">
+        The La Sfera Project respects the intellectual property rights of others.
+        Per the DMCA, the La Sfera Project will respond expeditiously to claims of
+        copyright infringement on the Site if submitted to the La Sfera Project's
+        contact email address as described below. Upon receipt of a notice
+        alleging copyright infringement, the La Sfera Project will take whatever
+        action it deems appropriate within its sole discretion, including removal
+        of the allegedly infringing materials and termination of access for repeat
+        infringers of copyright protected content.
+      </p>
+
+      <p class="prose mb-4">
+        If you believe that your intellectual property rights have been violated
+        by the La Sfera Project or by a third party who has uploaded materials to
+        our website, please provide the following information to the email address
+        listed below:
+      </p>
+
+      <ol class="mb-4 list-decimal text-gray-700 max-w-[65ch] ml-4 pr-4">
+        <li>
+          A description of the copyrighted work or other intellectual property
+          that you claim has been infringed;
+        </li>
+        <li>
+          A description of where the material that you claim is infringing is
+          located on the Site;
+        </li>
+        <li>An email address where we can contact you;</li>
+        <li>
+          A statement that you have a good-faith belief that the use is not
+          authorized by the copyright owner or other intellectual property rights
+          owner, by its agent, or by law;
+        </li>
+        <li>
+          A statement by you under penalty of perjury that the information in your
+          notice is accurate and that you are the copyright or intellectual
+          property owner or are authorized to act on the owner's behalf;
+        </li>
+        <li>Your electronic or physical signature.</li>
+      </ol>
+
+      <p class="prose mb-4">
+        The La Sfera Project may request additional information before removing
+        any allegedly infringing material. In the event the La Sfera Project
+        removes the allegedly infringing materials, the La Sfera Project will
+        immediately notify the person responsible for posting such materials that
+        the La Sfera Project removed or disabled access to the materials. The La
+        Sfera Project may also provide the responsible person with your email
+        address so that the person may respond to your allegations.
+      </p>
+
+      <p class="prose mb-4">
+        Contact the La Sfera Project via email:
+        <a class="hover:no-underline" href="mailto:datis.sfera@gmail.com">datis.sfera@gmail.com</a>
+      </p>
+    </section>
+  </div>
+{% endblock %}

--- a/templates/manuscripts.html
+++ b/templates/manuscripts.html
@@ -1,43 +1,42 @@
 {% extends "base.html" %}
 {% load static %}
-{% load stanza_tags %}
+{% load stanza_tags wagtailcore_tags %}
 
 {% block title %}Manuscript Traditions - La Sfera{% endblock title %}
 
 {% block content %}
-    <div class="mx-auto container pt-3">
+  <div class="mx-auto container pt-3">
     <section class="w-full p-4 my-10">
-        <!-- Title -->
-        <h3 class="text-4xl mb-8 font-bold" id="top">
-            {{ snippet.title|default:"Manuscripts" }}
-        </h3>
-        <div class="prose mb-8">
-            {% if snippet.body %}
-                {{ snippet.body|safe }}
-            {% else %}
-                <p>
-                    This is an index of all of the manuscripts catalogued by the project
-                    that contain <em>La sfera</em>, with links to metadata and digitized
-                    materials.
-                </p>
-            {% endif %}
-        </div>
-        <ul>
+      <!-- Title -->
+      <h3 class="text-4xl mb-8 font-bold" id="top">
+        {{ snippet.title|default:"Manuscripts" }}
+      </h3>
+      <div class="prose mb-8">
+        {% if snippet.body %}
+          {{ snippet.body|richtext }}
+        {% else %}
+          <p>
+            This is an index of all of the manuscripts catalogued by the project
+            that contain <em>La sfera</em>, with links to metadata and digitized
+            materials.
+          </p>
+        {% endif %}
+      </div>
+      <ul>
         {% for manuscript in manuscripts %}
-            <li>
-                {% if manuscript.siglum %}
-                    <a class="underline hover:no-underline" href="{% url 'manuscript' manuscript.siglum %}">
-                        {{ manuscript.shelfmark_fmt|default:manuscript.siglum }}
-                    </a>
-                {% else %}
-                    {{ manuscript.shelfmark_fmt|default:manuscript.siglum }}
-                {% endif %}
-            </li>
+          <li>
+            {% if manuscript.siglum %}
+              <a class="underline hover:no-underline" href="{% url 'manuscript' manuscript.siglum %}">
+                {{ manuscript.shelfmark_fmt|default:manuscript.siglum }}
+              </a>
+            {% else %}
+              {{ manuscript.shelfmark_fmt|default:manuscript.siglum }}
+            {% endif %}
+          </li>
         {% endfor %}
-        </ul>
-        </div>
+      </ul>
     </section>
-</div>
+  </div>
 {% endblock content %}
 
 {% block scripts %}


### PR DESCRIPTION
### In this PR

Per https://github.com/chnm/lasfera/issues/128:
- Add DMCA policy to website with a link to the new email address
- Add link to it on Gallery page

Unrelated:
- Some cleanup for `/manuscripts`