### PR TITLE
Hide line codes on edition by default (#15)

### DIFF
--- a/static/js/annotations.js
+++ b/static/js/annotations.js
@@ -284,27 +284,3 @@ function annotateText(text, annotations) {
     
     return result;
 }
-
-// Function to handle line code display
-function updateLineCodeDisplay(mode) {
-    const lineCodes = document.querySelectorAll('.line-code');
-    lineCodes.forEach(code => {
-        switch(mode) {
-            case 'shortened':
-                // Show only last part of line code (e.g., "01" from "01.01.01")
-                const shortCode = code.textContent.trim().split('.').pop();
-                code.style.display = '';
-                code.querySelector('span').textContent = shortCode;
-                break;
-            case 'hidden':
-                code.style.display = 'none';
-                break;
-            default: // 'full'
-                code.style.display = '';
-                // Restore original line code if needed
-                const originalCode = code.querySelector('a').id;
-                code.querySelector('span').textContent = originalCode;
-        }
-    });
-}
-

--- a/static/js/stanza.js
+++ b/static/js/stanza.js
@@ -1,46 +1,25 @@
 // Handle toggling line codes
-document.addEventListener("DOMContentLoaded", (event) => {
+(function() {
   const lineCodeDisplay = document.getElementById("lineCodeDisplay");
   if (lineCodeDisplay) {
-    let originalLineCodes = [];
-    let lineCodesVisible = true;
-
     lineCodeDisplay.addEventListener("change", function () {
-      const lineCodes = document.querySelectorAll(".line-code");
-      const lineCodeLinks = document.querySelectorAll(".line-code a");
-
-      switch (this.value) {
-        case "full":
-          // Show full line codes
-          lineCodes.forEach((code) => (code.style.display = "inline"));
-          if (originalLineCodes.length) {
-            lineCodeLinks.forEach((link, i) => {
-              link.querySelector("span").textContent = originalLineCodes[i];
-            });
-          }
-          break;
-
-        case "shortened":
-          // Show shortened line codes
-          lineCodes.forEach((code) => (code.style.display = "inline"));
-          lineCodeLinks.forEach((link, i) => {
-            const span = link.querySelector("span");
-            if (!originalLineCodes[i]) {
-              originalLineCodes[i] = span.textContent;
-            }
-            const parts = span.textContent.split(".");
-            span.textContent = parseInt(parts[parts.length - 1]);
-          });
-          break;
-
-        case "hidden":
-          // Hide line codes
-          lineCodes.forEach((code) => (code.style.display = "none"));
-          break;
-      }
+      const mode = this.value; // "hidden", "shortened", or "full"
+      updateLineCodeDisplay(mode, this);
     });
   }
-});
+  const handleHash = () => {
+    const hash = window.location.hash;
+    if (hash) {
+      const id = decodeURIComponent(hash.substring(1));
+      const target = document.getElementById(id);
+      if (target) {
+        this.updateLineCodeDisplay("full", lineCodeDisplay);
+      }
+    }
+  };
+  window.addEventListener("hashchange", handleHash);
+  handleHash();
+})();
 
 // Return to top button
 window.addEventListener("scroll", function () {
@@ -62,25 +41,28 @@ window.addEventListener("scroll", function () {
   }
 });
 
-// Function to update the line code display
-function updateLineCodeDisplay(mode) {
-  const lineCodes = document.querySelectorAll('.line-code');
-  lineCodes.forEach(code => {
-    switch(mode) {
-      case 'shortened':
-        // Show only last part of line code (e.g., "01" from "01.01.01")
-        const shortCode = code.textContent.trim().split('.').pop();
-        code.style.display = '';
-        code.querySelector('span').textContent = shortCode;
-        break;
-      case 'hidden':
-        code.style.display = 'none';
-        break;
-      default: // 'full'
-        code.style.display = '';
-        // Restore original line code if needed
-        const originalCode = code.querySelector('a').id;
-        code.querySelector('span').textContent = originalCode;
+function updateLineCodeDisplay(mode, selectElement) {
+  const lineCodeLinks = document.querySelectorAll("a.line-code");
+  lineCodeLinks.forEach((a) => {
+    const span = a.querySelector(".line-text");
+    const fullCode = a.id;
+
+    if (mode === "shortened") {
+      // Show only last part of line code (e.g., "1" from "01.01.01")
+      const parts = fullCode.split(".");
+      span.textContent = parseInt(parts[parts.length - 1]);
+    } else {
+      span.textContent = fullCode;
+    }
+
+    if (mode === "hidden") {
+      // Hide line codes
+      a.classList.add("sr-only");
+    } else {
+      a.classList.remove("sr-only");
     }
   });
+  if (selectElement && mode) {
+    selectElement.value = mode;
+  }
 }

--- a/templates/stanzas.html
+++ b/templates/stanzas.html
@@ -162,7 +162,7 @@
                     <select id="lineCodeDisplay" class="w-full p-2 border border-gray-300 rounded-md shadow-sm focus:border-blue-500 focus:ring-blue-500">
                       <option value="full">Show line codes</option>
                       <option value="shortened">Show shortened line codes</option>
-                      <option value="hidden">Hide line codes</option>
+                      <option value="hidden" selected>Hide line codes</option>
                     </select>
                   </div>
                 </div>
@@ -205,21 +205,19 @@
                     <div class="w-full">
                       {% for stanza in stanza_pair.original %}
                         <div class="relative">
-                          <div class="flex items-start">
-                            <span class="line-code mr-2">
-                              <a class="no-underline scroll-mt-20" 
-                                 href="{% url 'manuscript_stanzas' default_manuscript.siglum %}#{{stanza.stanza_line_code_starts}}"
-                                 id="{{stanza.stanza_line_code_starts}}"
-                                 title="Anchor link to line code {{ stanza.stanza_line_code_starts}}"
-                                 {% with stanza_folio=stanza.folios.all.0 %}
-                                 data-folio="{{ stanza_folio.folio_number }}"
-                                 {% endwith %}
-                                 onclick="navigateToFolio(event, this)">
-                                <span class="font-serif text-red-700 text-sm">
-                                  {{ stanza.stanza_line_code_starts }}
-                                </span>
-                              </a>
-                            </span>
+                          <div class="flex gap-2 items-start">
+                            <a class="line-code sr-only target:not-sr-only no-underline scroll-mt-20" 
+                                href="{% url 'manuscript_stanzas' default_manuscript.siglum %}#{{stanza.stanza_line_code_starts}}"
+                                id="{{stanza.stanza_line_code_starts}}"
+                                title="Anchor link to line code {{ stanza.stanza_line_code_starts}}"
+                                {% with stanza_folio=stanza.folios.all.0 %}
+                                data-folio="{{ stanza_folio.folio_number }}"
+                                {% endwith %}
+                                onclick="navigateToFolio(event, this)">
+                              <span class="line-text font-serif text-red-700 text-sm">
+                                {{ stanza.stanza_line_code_starts }}
+                              </span>
+                            </a>
                             <span class="flex-1 pl-4{% if stanza.is_rubric %} text-xl font-bold{% endif %}">
                               {{ stanza.unescaped_stanza_text|annotate_text:stanza.annotations|safe }}
                             </span>
@@ -232,15 +230,13 @@
                     <div class="w-full">
                       {% for stanza in stanza_pair.translated %}
                         <div class="relative">
-                          <div class="flex items-start">
-                            <span class="line-code mr-2">
-                              <a class="no-underline scroll-mt-20" href="#{{stanza.stanza_line_code_starts}}"
-                                 id="{{stanza.stanza_line_code_starts}}">
-                                <span class="font-serif text-red-700 text-sm">
-                                  {{ stanza.stanza_line_code_starts }}
-                                </span>
-                              </a>
-                            </span>
+                          <div class="flex gap-2 items-start">
+                            <a class="line-code sr-only target:not-sr-only no-underline scroll-mt-20" href="#{{stanza.stanza_line_code_starts}}"
+                                id="{{stanza.stanza_line_code_starts}}">
+                              <span class="line-text font-serif text-red-700 text-sm">
+                                {{ stanza.stanza_line_code_starts }}
+                              </span>
+                            </a>
                             <span class="flex-1 pl-4{% if stanza.is_rubric %} text-xl font-bold{% endif %}">
                               {{ stanza.unescaped_stanza_text|annotate_text:stanza.annotations|safe }}
                             </span>


### PR DESCRIPTION
### In this PR

Per #15:
- Line codes hidden, and "hide" selected, by default on Edition page
- If a user visits the edition page from an anchor link to a specific line code, though, show them all instead